### PR TITLE
Add reset button to take the user to step 1 in the array algorithms

### DIFF
--- a/src/pages/array-algorithms/2d-arrays.tsx
+++ b/src/pages/array-algorithms/2d-arrays.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Grid, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface MatrixCell {
   value: number
@@ -616,6 +617,9 @@ return False`,
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/bit-manipulation.tsx
+++ b/src/pages/array-algorithms/bit-manipulation.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Binary, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface BitElement {
   value: number
@@ -502,6 +503,9 @@ def reverse_all_bits(nums):
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/hashing.tsx
+++ b/src/pages/array-algorithms/hashing.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Hash, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number | string
@@ -682,6 +683,9 @@ return None`,
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/kadanes.tsx
+++ b/src/pages/array-algorithms/kadanes.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, TrendingUp, ChevronLeft, ChevronRight, Code, Play, Pause, RotateCcw } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number
@@ -410,6 +411,9 @@ return maxSoFar  # ${maxSoFar}`,
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/monotonic-stack.tsx
+++ b/src/pages/array-algorithms/monotonic-stack.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Layers, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number
@@ -587,6 +588,9 @@ return result`,
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/prefix-sum.tsx
+++ b/src/pages/array-algorithms/prefix-sum.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Calculator, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number
@@ -277,6 +278,9 @@ range_sum = prefix_sum[end + 1] - prefix_sum[start]`
                 </div>
               </div>
               <p className="text-gray-600 mb-4">{steps[currentStep].description}</p>
+              <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                Reset
+              </Button>
             </div>
 
             {/* Array Visualization */}

--- a/src/pages/array-algorithms/sliding-window.tsx
+++ b/src/pages/array-algorithms/sliding-window.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, Grid, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number
@@ -384,6 +385,9 @@ return ${selectedAlgorithm === "max-sum" ? "maxSum" : selectedAlgorithm === "min
                     </button>
                   </div>
                 </div>
+                <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                  Reset
+                </Button>
               </div>
             </div>
 

--- a/src/pages/array-algorithms/two-pointer.tsx
+++ b/src/pages/array-algorithms/two-pointer.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight, Code } from "lucide-react"
+import { Button } from "../../components/ui/button"
 
 interface ArrayElement {
   value: number
@@ -371,6 +372,9 @@ return []`
                 </div>
               </div>
               <p className="text-gray-600 mb-4">{steps[currentStep].description}</p>
+              <Button onClick={()=> setCurrentStep(0)} variant="secondary">
+                Reset
+              </Button>
             </div>
 
             {/* Array Visualization */}


### PR DESCRIPTION
Closes #10
### PR Summary

This PR adds a **Reset** button to multiple algorithm pages for resetting the current step in the visualization. The change is applied in the following files:

- **2d-arrays.tsx**
- **bit-manipulation.tsx**
- **hashing.tsx**
- **kadanes.tsx**
- **monotonic-stack.tsx**
- **prefix-sum.tsx**
- **sliding-window.tsx**
- **two-pointer.tsx**

---

### Changes Overview

- **Type of Changes:**  
  - A new button component is added across multiple algorithm pages to reset the current step.
  
- **Impact:**  
  - Improves interactivity by allowing users to restart the algorithm visualizations.
<img width="1151" height="796" alt="Screenshot 2025-10-12 183352" src="https://github.com/user-attachments/assets/c9b4a780-dc88-4c8c-9b8c-62496037ad8a" />


