### PR TITLE
Fix the visualize button disable fix on square matrix error

### DIFF
--- a/src/pages/array-algorithms/2d-arrays.tsx
+++ b/src/pages/array-algorithms/2d-arrays.tsx
@@ -339,6 +339,7 @@ return False`,
           break
         case "rotate":
           if (matrix.length !== cols) {
+            setIsVisualizing(false)
             throw new Error("Matrix must be square for rotation")
           }
           newSteps = generateRotateSteps(matrix)


### PR DESCRIPTION
Close #47

### PR Summary

This PR fix an error to the **2D Arrays** re-enable the visualization button when not square matrix error is thrown.

---

### Changes Overview

- **File Updated:**  
  - `src/pages/array-algorithms/2d-arrays.tsx`
