### PR TITLE
Fix: Adjust sorting visualizer zoom threshold to 15 elements (#69)

### DIFF
--- a/src/components/SortingVisualizer.tsx
+++ b/src/components/SortingVisualizer.tsx
@@ -169,7 +169,7 @@ const SortingVisualizer: React.FC<SortingVisualizerProps> = ({ algorithm, inputA
           </div>
         </div>
 
-        {steps[currentStep]?.array.length >= 100 ? (
+        {steps[currentStep]?.array.length >= 15 ? (
           <div className="flex justify-center">
             <ZoomableArrayCanvas
               elements={prepareCanvasElements()}


### PR DESCRIPTION
## Description

Adjusted the sorting visualizer's zoom threshold from 100 to 15 elements.
Now, zooming and panning are enabled for arrays with 15 or more elements to improve usability for smaller datasets.

## Testing

Go to the sorting visualizer

- Input an array with more than 15 elements → zoom/pan should activate
- Input an array with fewer than 15 elements → normal view should appear

## Issue

Closes #69