### PR TITLE
Feat: Add keyboard navigation for next and previous buttons (#98)

### DIFF
--- a/src/components/SortingVisualizer.tsx
+++ b/src/components/SortingVisualizer.tsx
@@ -72,6 +72,21 @@ const SortingVisualizer: React.FC<SortingVisualizerProps> = ({ algorithm, inputA
     })
   }, [algorithm, inputArray])
 
+  // Keyboard navigation accessibility
+useEffect(() => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "ArrowLeft") {
+      handlePrevious()
+    } else if (event.key === "ArrowRight") {
+      handleNext()
+    }
+  }
+
+  window.addEventListener("keydown", handleKeyDown)
+  return () => window.removeEventListener("keydown", handleKeyDown)
+}, [currentStep, steps.length])
+
+
   // Auto-play functionality
   useEffect(() => {
     let interval: NodeJS.Timeout
@@ -248,14 +263,14 @@ const SortingVisualizer: React.FC<SortingVisualizerProps> = ({ algorithm, inputA
             <RotateCcw className="w-4 h-4 mr-1" />
             Reset
           </Button>
-          <Button onClick={handlePrevious} disabled={currentStep === 0} variant="secondary">
+          <Button onClick={handlePrevious} disabled={currentStep === 0} variant="secondary"  aria-label="Go to previous step">
             Previous
           </Button>
           <Button onClick={togglePlay} variant={isPlaying ? "secondary" : "primary"} size="sm">
             {isPlaying ? <Pause className="w-4 h-4 mr-1" /> : <Play className="w-4 h-4 mr-1" />}
             {isPlaying ? "Pause" : "Play"}
           </Button>
-          <Button onClick={handleNext} disabled={currentStep === steps.length - 1}>
+          <Button onClick={handleNext} disabled={currentStep === steps.length - 1} aria-label="Go to next step">
             Next
           </Button>
         </div>


### PR DESCRIPTION
##  Description
Implemented keyboard accessibility for navigating between steps using the **Left (←)** and **Right (→)** arrow keys.  
Also added `aria-label` attributes to enhance screen reader support.

---

## Changes Made
- Added keyboard event listener for step navigation  
- Enhanced button accessibility with `aria-label` attributes  

---

## Testing
- Pressing **→** moves to the next step  
- Pressing **←** moves to the previous step  
- Buttons remain fully functional  