### PR TITLE
Add Trie Section under Data Structure & Algorithm Card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import PageLoader from "./components/PageLoader";
 import { useTheme } from "./contexts/ThemeContext";
 import ScrollToTop from "./components/scrollToTop";
 import AIAssistantPage from "./pages/AIAssistantPage"
-import ScrollToTop from "./components/scrollToTop";
 
 // Lazy load all page components
 const Home = lazy(() => import("./page"));

--- a/src/page.tsx
+++ b/src/page.tsx
@@ -86,6 +86,7 @@ export default function Page() {
         { name: "Binary Tree", path: "/data-structures/binary-tree", description: "Hierarchical tree structure" },
         { name: "Stack", path: "/data-structures/stack", description: "LIFO data structure" },
         { name: "Queue", path: "/data-structures/queue", description: "FIFO data structure" },
+        { name: "Trie", path: "/data-structures/trie", description: "Trie data structure and algorithms" },
         { name: "Graph", path: "/data-structures/graph", description: "Graph data structure and algorithms" },
       ],
     },


### PR DESCRIPTION
### Related Issue
Closes #148


### Summary
Added a Trie section under the Data Structure & Algorithm card on the main page.

### Changes Made
- Positioned the section under the existing Data Structure & Algorithm card for easy access.

### Hacktoberfest
This PR is a valid contribution for **Hacktoberfest**.  
Kindly add the `hacktoberfest` label to this PR.