### PR TITLE
Fix Dark Mode Compatibility on Expression Converter Page

### DIFF
--- a/src/pages/ExpressionConverterPage.tsx
+++ b/src/pages/ExpressionConverterPage.tsx
@@ -1,85 +1,105 @@
-"use client"
-import { useState } from "react"
-import { Link } from "react-router-dom"
-import { ArrowLeft, Calculator, ChevronLeft, ChevronRight, Code } from 'lucide-react'
+"use client";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  ArrowLeft,
+  Calculator,
+  ChevronLeft,
+  ChevronRight,
+  Code,
+} from "lucide-react";
 
 interface StackElement {
-  value: string
-  isActive: boolean
-  isOperator: boolean
+  value: string;
+  isActive: boolean;
+  isOperator: boolean;
 }
 
 interface Step {
-  input: string
-  stack: StackElement[]
-  output: string[]
-  currentToken: string
-  description: string
-  code: string
-  tokenIndex: number
+  input: string;
+  stack: StackElement[];
+  output: string[];
+  currentToken: string;
+  description: string;
+  code: string;
+  tokenIndex: number;
 }
 
-type ConversionType = "infix-to-postfix" | "infix-to-prefix" | "postfix-to-infix" | "prefix-to-infix" | "postfix-to-prefix" | "prefix-to-postfix"
+type ConversionType =
+  | "infix-to-postfix"
+  | "infix-to-prefix"
+  | "postfix-to-infix"
+  | "prefix-to-infix"
+  | "postfix-to-prefix"
+  | "prefix-to-postfix";
 
 function ExpressionConverterPage() {
-  const [inputExpression, setInputExpression] = useState<string>("A + B * C - D")
-  const [conversionType, setConversionType] = useState<ConversionType>("infix-to-postfix")
-  const [steps, setSteps] = useState<Step[]>([])
-  const [currentStep, setCurrentStep] = useState<number>(0)
-  const [isVisualizing, setIsVisualizing] = useState<boolean>(false)
-  const [showFullCode, setShowFullCode] = useState<boolean>(false)
-  const [result, setResult] = useState<string>("")
+  const [inputExpression, setInputExpression] =
+    useState<string>("A + B * C - D");
+  const [conversionType, setConversionType] =
+    useState<ConversionType>("infix-to-postfix");
+  const [steps, setSteps] = useState<Step[]>([]);
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [isVisualizing, setIsVisualizing] = useState<boolean>(false);
+  const [showFullCode, setShowFullCode] = useState<boolean>(false);
+  const [result, setResult] = useState<string>("");
 
   const resetVisualization = () => {
-    setSteps([])
-    setCurrentStep(0)
-    setIsVisualizing(false)
-    setShowFullCode(false)
-    setResult("")
-  }
+    setSteps([]);
+    setCurrentStep(0);
+    setIsVisualizing(false);
+    setShowFullCode(false);
+    setResult("");
+  };
 
   // Utility functions
   const isOperator = (char: string): boolean => {
-    return ['+', '-', '*', '/', '^', '(', ')'].includes(char)
-  }
+    return ["+", "-", "*", "/", "^", "(", ")"].includes(char);
+  };
 
   const getPrecedence = (op: string): number => {
     switch (op) {
-      case '+':
-      case '-':
-        return 1
-      case '*':
-      case '/':
-        return 2
-      case '^':
-        return 3
+      case "+":
+      case "-":
+        return 1;
+      case "*":
+      case "/":
+        return 2;
+      case "^":
+        return 3;
       default:
-        return 0
+        return 0;
     }
-  }
+  };
 
   const isRightAssociative = (op: string): boolean => {
-    return op === '^'
-  }
+    return op === "^";
+  };
 
   const tokenize = (expression: string): string[] => {
-    return expression.replace(/\s+/g, '').split('').filter(char => char !== ' ')
-  }
+    return expression
+      .replace(/\s+/g, "")
+      .split("")
+      .filter((char) => char !== " ");
+  };
 
   const reverseString = (str: string): string => {
-    return str.split('').reverse().join('')
-  }
+    return str.split("").reverse().join("");
+  };
 
   const swapParentheses = (expression: string): string => {
-    return expression.replace(/$$/g, 'TEMP').replace(/$$/g, '(').replace(/TEMP/g, ')')
-  }
+    return expression
+      .replace(/$$/g, "TEMP")
+      .replace(/$$/g, "(")
+      .replace(/TEMP/g, ")");
+  };
 
   // Infix to Postfix conversion
   const generateInfixToPostfixSteps = (expression: string) => {
-    const newSteps: Step[] = []
-    const tokens = tokenize(expression)
-    const stack: string[] = []
-    const output: string[] = []
+    const newSteps: Step[] = [];
+    const tokens = tokenize(expression);
+    const stack: string[] = [];
+    const output: string[] = [];
 
     // Initial state
     newSteps.push({
@@ -92,14 +112,14 @@ function ExpressionConverterPage() {
 stack = []
 output = []`,
       tokenIndex: -1,
-    })
+    });
 
     for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i]
+      const token = tokens[i];
 
       if (!isOperator(token)) {
         // Operand
-        output.push(token)
+        output.push(token);
         newSteps.push({
           input: expression,
           stack: stack.map((item, idx) => ({
@@ -114,10 +134,10 @@ output = []`,
 if isOperand(token):
     output.append(token)`,
           tokenIndex: i,
-        })
-      } else if (token === '(') {
+        });
+      } else if (token === "(") {
         // Left parenthesis
-        stack.push(token)
+        stack.push(token);
         newSteps.push({
           input: expression,
           stack: stack.map((item, idx) => ({
@@ -132,12 +152,12 @@ if isOperand(token):
 if token == '(':
     stack.append(token)`,
           tokenIndex: i,
-        })
-      } else if (token === ')') {
+        });
+      } else if (token === ")") {
         // Right parenthesis
-        while (stack.length > 0 && stack[stack.length - 1] !== '(') {
-          const poppedOp = stack.pop()!
-          output.push(poppedOp)
+        while (stack.length > 0 && stack[stack.length - 1] !== "(") {
+          const poppedOp = stack.pop()!;
+          output.push(poppedOp);
           newSteps.push({
             input: expression,
             stack: stack.map((item, idx) => ({
@@ -152,10 +172,10 @@ if token == '(':
 while stack and stack[-1] != '(':
     output.append(stack.pop())`,
             tokenIndex: i,
-          })
+          });
         }
         if (stack.length > 0) {
-          stack.pop() // Remove the '('
+          stack.pop(); // Remove the '('
         }
         newSteps.push({
           input: expression,
@@ -170,17 +190,18 @@ while stack and stack[-1] != '(':
           code: `# Remove left parenthesis
 stack.pop()  # Remove '('`,
           tokenIndex: i,
-        })
+        });
       } else {
         // Operator
         while (
           stack.length > 0 &&
-          stack[stack.length - 1] !== '(' &&
+          stack[stack.length - 1] !== "(" &&
           (getPrecedence(stack[stack.length - 1]) > getPrecedence(token) ||
-            (getPrecedence(stack[stack.length - 1]) === getPrecedence(token) && !isRightAssociative(token)))
+            (getPrecedence(stack[stack.length - 1]) === getPrecedence(token) &&
+              !isRightAssociative(token)))
         ) {
-          const poppedOp = stack.pop()!
-          output.push(poppedOp)
+          const poppedOp = stack.pop()!;
+          output.push(poppedOp);
           newSteps.push({
             input: expression,
             stack: stack.map((item, idx) => ({
@@ -195,9 +216,9 @@ stack.pop()  # Remove '('`,
 while (stack and precedence(stack[-1]) >= precedence(token)):
     output.append(stack.pop())`,
             tokenIndex: i,
-          })
+          });
         }
-        stack.push(token)
+        stack.push(token);
         newSteps.push({
           input: expression,
           stack: stack.map((item, idx) => ({
@@ -211,14 +232,14 @@ while (stack and precedence(stack[-1]) >= precedence(token)):
           code: `# Push current operator
 stack.append(token)`,
           tokenIndex: i,
-        })
+        });
       }
     }
 
     // Pop remaining operators
     while (stack.length > 0) {
-      const poppedOp = stack.pop()!
-      output.push(poppedOp)
+      const poppedOp = stack.pop()!;
+      output.push(poppedOp);
       newSteps.push({
         input: expression,
         stack: stack.map((item, idx) => ({
@@ -233,7 +254,7 @@ stack.append(token)`,
 while stack:
     output.append(stack.pop())`,
         tokenIndex: -1,
-      })
+      });
     }
 
     // Final result
@@ -242,22 +263,22 @@ while stack:
       stack: [],
       output: [...output],
       currentToken: "",
-      description: `Conversion complete! Postfix: ${output.join(' ')}`,
+      description: `Conversion complete! Postfix: ${output.join(" ")}`,
       code: `# Return postfix expression
 return ''.join(output)`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: output.join(' ') }
-  }
+    return { steps: newSteps, result: output.join(" ") };
+  };
 
   // Infix to Prefix conversion
   const generateInfixToPrefixSteps = (expression: string) => {
-    const newSteps: Step[] = []
-    
+    const newSteps: Step[] = [];
+
     // Step 1: Reverse the expression and swap parentheses
-    const reversedExpr = swapParentheses(reverseString(expression))
-    
+    const reversedExpr = swapParentheses(reverseString(expression));
+
     newSteps.push({
       input: expression,
       stack: [],
@@ -268,45 +289,46 @@ return ''.join(output)`,
 # Step 1: Reverse and swap parentheses
 reversed_expr = reverse_and_swap("${expression}")`,
       tokenIndex: -1,
-    })
+    });
 
     // Step 2: Convert to postfix
-    const { steps: postfixSteps, result: postfixResult } = generateInfixToPostfixSteps(reversedExpr)
-    
+    const { steps: postfixSteps, result: postfixResult } =
+      generateInfixToPostfixSteps(reversedExpr);
+
     // Add postfix conversion steps
     postfixSteps.forEach((step, index) => {
-      if (index === 0) return // Skip initial step
+      if (index === 0) return; // Skip initial step
       newSteps.push({
         ...step,
         description: `Step 2: ${step.description}`,
         code: `# Converting reversed expression to postfix
 ${step.code}`,
-      })
-    })
+      });
+    });
 
     // Step 3: Reverse the result
-    const finalResult = reverseString(postfixResult.replace(/\s+/g, ''))
-    
+    const finalResult = reverseString(postfixResult.replace(/\s+/g, ""));
+
     newSteps.push({
       input: expression,
       stack: [],
-      output: finalResult.split(''),
+      output: finalResult.split(""),
       currentToken: "",
       description: `Step 3: Reverse postfix result: "${finalResult}"`,
       code: `# Step 3: Reverse the postfix result
 prefix_result = reverse("${postfixResult}")
 return prefix_result`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: finalResult.split('').join(' ') }
-  }
+    return { steps: newSteps, result: finalResult.split("").join(" ") };
+  };
 
   // Postfix to Infix conversion
   const generatePostfixToInfixSteps = (expression: string) => {
-    const newSteps: Step[] = []
-    const tokens = tokenize(expression)
-    const stack: string[] = []
+    const newSteps: Step[] = [];
+    const tokens = tokenize(expression);
+    const stack: string[] = [];
 
     newSteps.push({
       input: expression,
@@ -317,14 +339,14 @@ return prefix_result`,
       code: `# Postfix to Infix Conversion
 stack = []`,
       tokenIndex: -1,
-    })
+    });
 
     for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i]
+      const token = tokens[i];
 
       if (!isOperator(token)) {
         // Operand
-        stack.push(token)
+        stack.push(token);
         newSteps.push({
           input: expression,
           stack: stack.map((item, idx) => ({
@@ -339,15 +361,15 @@ stack = []`,
 if isOperand(token):
     stack.append(token)`,
           tokenIndex: i,
-        })
-      } else if (token !== '(' && token !== ')') {
+        });
+      } else if (token !== "(" && token !== ")") {
         // Operator
         if (stack.length >= 2) {
-          const operand2 = stack.pop()!
-          const operand1 = stack.pop()!
-          const infixExpr = `(${operand1}${token}${operand2})`
-          stack.push(infixExpr)
-          
+          const operand2 = stack.pop()!;
+          const operand1 = stack.pop()!;
+          const infixExpr = `(${operand1}${token}${operand2})`;
+          stack.push(infixExpr);
+
           newSteps.push({
             input: expression,
             stack: stack.map((item, idx) => ({
@@ -364,12 +386,12 @@ operand1 = stack.pop()
 infix_expr = f"({operand1}{token}{operand2})"
 stack.append(infix_expr)`,
             tokenIndex: i,
-          })
+          });
         }
       }
     }
 
-    const finalResult = stack.length > 0 ? stack[0] : ""
+    const finalResult = stack.length > 0 ? stack[0] : "";
     newSteps.push({
       input: expression,
       stack: stack.map((item, idx) => ({
@@ -383,36 +405,37 @@ stack.append(infix_expr)`,
       code: `# Return final infix expression
 return stack[0]`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: finalResult }
-  }
+    return { steps: newSteps, result: finalResult };
+  };
 
   // Prefix to Infix conversion
   const generatePrefixToInfixSteps = (expression: string) => {
-    const newSteps: Step[] = []
-    const tokens = tokenize(expression)
-    const stack: string[] = []
+    const newSteps: Step[] = [];
+    const tokens = tokenize(expression);
+    const stack: string[] = [];
 
     newSteps.push({
       input: expression,
       stack: [],
       output: [],
       currentToken: "",
-      description: "Initialize stack for prefix to infix conversion (process right to left)",
+      description:
+        "Initialize stack for prefix to infix conversion (process right to left)",
       code: `# Prefix to Infix Conversion
 stack = []
 # Process from right to left`,
       tokenIndex: -1,
-    })
+    });
 
     // Process from right to left
     for (let i = tokens.length - 1; i >= 0; i--) {
-      const token = tokens[i]
+      const token = tokens[i];
 
       if (!isOperator(token)) {
         // Operand
-        stack.push(token)
+        stack.push(token);
         newSteps.push({
           input: expression,
           stack: stack.map((item, idx) => ({
@@ -427,15 +450,15 @@ stack = []
 if isOperand(token):
     stack.append(token)`,
           tokenIndex: i,
-        })
-      } else if (token !== '(' && token !== ')') {
+        });
+      } else if (token !== "(" && token !== ")") {
         // Operator
         if (stack.length >= 2) {
-          const operand1 = stack.pop()!
-          const operand2 = stack.pop()!
-          const infixExpr = `(${operand1}${token}${operand2})`
-          stack.push(infixExpr)
-          
+          const operand1 = stack.pop()!;
+          const operand2 = stack.pop()!;
+          const infixExpr = `(${operand1}${token}${operand2})`;
+          stack.push(infixExpr);
+
           newSteps.push({
             input: expression,
             stack: stack.map((item, idx) => ({
@@ -452,12 +475,12 @@ operand2 = stack.pop()
 infix_expr = f"({operand1}{token}{operand2})"
 stack.append(infix_expr)`,
             tokenIndex: i,
-          })
+          });
         }
       }
     }
 
-    const finalResult = stack.length > 0 ? stack[0] : ""
+    const finalResult = stack.length > 0 ? stack[0] : "";
     newSteps.push({
       input: expression,
       stack: stack.map((item, idx) => ({
@@ -471,18 +494,18 @@ stack.append(infix_expr)`,
       code: `# Return final infix expression
 return stack[0]`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: finalResult }
-  }
+    return { steps: newSteps, result: finalResult };
+  };
 
   // Postfix to Prefix conversion
   const generatePostfixToPrefixSteps = (expression: string) => {
     // Convert postfix to infix first, then infix to prefix
-    const { result: infixResult } = generatePostfixToInfixSteps(expression)
-    const { result: prefixResult } = generateInfixToPrefixSteps(infixResult)
-    
-    const newSteps: Step[] = []
+    const { result: infixResult } = generatePostfixToInfixSteps(expression);
+    const { result: prefixResult } = generateInfixToPrefixSteps(infixResult);
+
+    const newSteps: Step[] = [];
     newSteps.push({
       input: expression,
       stack: [],
@@ -493,18 +516,18 @@ return stack[0]`,
 infix_result = postfix_to_infix("${expression}")
 prefix_result = infix_to_prefix(infix_result)`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: prefixResult }
-  }
+    return { steps: newSteps, result: prefixResult };
+  };
 
   // Prefix to Postfix conversion
   const generatePrefixToPostfixSteps = (expression: string) => {
     // Convert prefix to infix first, then infix to postfix
-    const { result: infixResult } = generatePrefixToInfixSteps(expression)
-    const { result: postfixResult } = generateInfixToPostfixSteps(infixResult)
-    
-    const newSteps: Step[] = []
+    const { result: infixResult } = generatePrefixToInfixSteps(expression);
+    const { result: postfixResult } = generateInfixToPostfixSteps(infixResult);
+
+    const newSteps: Step[] = [];
     newSteps.push({
       input: expression,
       stack: [],
@@ -515,53 +538,55 @@ prefix_result = infix_to_prefix(infix_result)`,
 infix_result = prefix_to_infix("${expression}")
 postfix_result = infix_to_postfix(infix_result)`,
       tokenIndex: -1,
-    })
+    });
 
-    return { steps: newSteps, result: postfixResult }
-  }
+    return { steps: newSteps, result: postfixResult };
+  };
 
   const handleVisualize = () => {
     try {
       if (!inputExpression.trim()) {
-        throw new Error("Please enter an expression")
+        throw new Error("Please enter an expression");
       }
 
-      resetVisualization()
-      setIsVisualizing(true)
+      resetVisualization();
+      setIsVisualizing(true);
 
-      let conversionResult: { steps: Step[]; result: string }
+      let conversionResult: { steps: Step[]; result: string };
 
       switch (conversionType) {
         case "infix-to-postfix":
-          conversionResult = generateInfixToPostfixSteps(inputExpression)
-          break
+          conversionResult = generateInfixToPostfixSteps(inputExpression);
+          break;
         case "infix-to-prefix":
-          conversionResult = generateInfixToPrefixSteps(inputExpression)
-          break
+          conversionResult = generateInfixToPrefixSteps(inputExpression);
+          break;
         case "postfix-to-infix":
-          conversionResult = generatePostfixToInfixSteps(inputExpression)
-          break
+          conversionResult = generatePostfixToInfixSteps(inputExpression);
+          break;
         case "prefix-to-infix":
-          conversionResult = generatePrefixToInfixSteps(inputExpression)
-          break
+          conversionResult = generatePrefixToInfixSteps(inputExpression);
+          break;
         case "postfix-to-prefix":
-          conversionResult = generatePostfixToPrefixSteps(inputExpression)
-          break
+          conversionResult = generatePostfixToPrefixSteps(inputExpression);
+          break;
         case "prefix-to-postfix":
-          conversionResult = generatePrefixToPostfixSteps(inputExpression)
-          break
+          conversionResult = generatePrefixToPostfixSteps(inputExpression);
+          break;
         default:
-          throw new Error("Invalid conversion type")
+          throw new Error("Invalid conversion type");
       }
 
-      setSteps(conversionResult.steps)
-      setResult(conversionResult.result)
-      setIsVisualizing(false)
+      setSteps(conversionResult.steps);
+      setResult(conversionResult.result);
+      setIsVisualizing(false);
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Please enter a valid expression")
-      setIsVisualizing(false)
+      alert(
+        err instanceof Error ? err.message : "Please enter a valid expression"
+      );
+      setIsVisualizing(false);
     }
-  }
+  };
 
   const getFullCode = () => {
     switch (conversionType) {
@@ -588,7 +613,7 @@ postfix_result = infix_to_postfix(infix_result)`,
     while stack:
         output.append(stack.pop())
     
-    return ''.join(output)`
+    return ''.join(output)`;
 
       case "infix-to-prefix":
         return `def infix_to_prefix(expression):
@@ -601,7 +626,7 @@ postfix_result = infix_to_postfix(infix_result)`,
     # Step 3: Reverse the result
     prefix = reverse(postfix)
     
-    return prefix`
+    return prefix`;
 
       case "postfix-to-infix":
         return `def postfix_to_infix(expression):
@@ -616,7 +641,7 @@ postfix_result = infix_to_postfix(infix_result)`,
             infix_expr = f"({operand1}{token}{operand2})"
             stack.append(infix_expr)
     
-    return stack[0]`
+    return stack[0]`;
 
       case "prefix-to-infix":
         return `def prefix_to_infix(expression):
@@ -632,35 +657,51 @@ postfix_result = infix_to_postfix(infix_result)`,
             infix_expr = f"({operand1}{token}{operand2})"
             stack.append(infix_expr)
     
-    return stack[0]`
+    return stack[0]`;
 
       case "postfix-to-prefix":
         return `def postfix_to_prefix(expression):
     # Convert via infix intermediate
     infix = postfix_to_infix(expression)
     prefix = infix_to_prefix(infix)
-    return prefix`
+    return prefix`;
 
       case "prefix-to-postfix":
         return `def prefix_to_postfix(expression):
     # Convert via infix intermediate
     infix = prefix_to_infix(expression)
     postfix = infix_to_postfix(infix)
-    return postfix`
+    return postfix`;
 
       default:
-        return ""
+        return "";
     }
-  }
+  };
 
   const conversionOptions = [
-    { value: "infix-to-postfix", label: "Infix → Postfix", example: "A + B * C" },
+    {
+      value: "infix-to-postfix",
+      label: "Infix → Postfix",
+      example: "A + B * C",
+    },
     { value: "infix-to-prefix", label: "Infix → Prefix", example: "A + B * C" },
-    { value: "postfix-to-infix", label: "Postfix → Infix", example: "A B C * +" },
+    {
+      value: "postfix-to-infix",
+      label: "Postfix → Infix",
+      example: "A B C * +",
+    },
     { value: "prefix-to-infix", label: "Prefix → Infix", example: "+ A * B C" },
-    { value: "postfix-to-prefix", label: "Postfix → Prefix", example: "A B C * +" },
-    { value: "prefix-to-postfix", label: "Prefix → Postfix", example: "+ A * B C" },
-  ]
+    {
+      value: "postfix-to-prefix",
+      label: "Postfix → Prefix",
+      example: "A B C * +",
+    },
+    {
+      value: "prefix-to-postfix",
+      label: "Prefix → Postfix",
+      example: "+ A * B C",
+    },
+  ];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
@@ -668,7 +709,10 @@ postfix_result = infix_to_postfix(infix_result)`,
         <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <Link to="/" className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+              <Link
+                to="/"
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              >
                 <ArrowLeft className="w-6 h-6 text-gray-600 dark:text-gray-300" />
               </Link>
               <div className="p-2 bg-gradient-to-r from-blue-500 to-purple-500 rounded-lg">
@@ -685,46 +729,66 @@ postfix_result = infix_to_postfix(infix_result)`,
       <main className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
         {/* Algorithm Info */}
         <div className="mb-8 bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Expression Notation Converter</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+            Expression Notation Converter
+          </h2>
           <p className="text-gray-600 dark:text-gray-300 mb-4">
-            Convert mathematical expressions between infix, prefix, and postfix notations with step-by-step visualization.
+            Convert mathematical expressions between infix, prefix, and postfix
+            notations with step-by-step visualization.
           </p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="p-3 bg-blue-50 rounded-lg">
-              <div className="font-semibold text-blue-800">Infix</div>
-              <div className="text-blue-700 text-sm">A + B * C (operators between operands)</div>
+            <div className="p-3 rounded-lg bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700">
+              <div className="font-semibold text-gray-900 dark:text-white">
+                Infix
+              </div>
+              <div className="text-gray-700 dark:text-gray-300 text-sm">
+                A + B * C (operators between operands)
+              </div>
             </div>
-            <div className="p-3 bg-purple-50 rounded-lg">
-              <div className="font-semibold text-purple-800">Prefix</div>
-              <div className="text-purple-700 text-sm">+ A * B C (operators before operands)</div>
+            <div className="p-3 rounded-lg bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700">
+              <div className="font-semibold text-gray-900 dark:text-white">
+                Prefix
+              </div>
+              <div className="text-gray-700 dark:text-gray-300 text-sm">
+                + A * B C (operators before operands)
+              </div>
             </div>
-            <div className="p-3 bg-green-50 rounded-lg">
-              <div className="font-semibold text-green-800">Postfix</div>
-              <div className="text-green-700 text-sm">A B C * + (operators after operands)</div>
+            <div className="p-3 rounded-lg bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700">
+              <div className="font-semibold text-gray-900 dark:text-white">
+                Postfix
+              </div>
+              <div className="text-gray-700 dark:text-gray-300 text-sm">
+                A B C * + (operators after operands)
+              </div>
             </div>
           </div>
         </div>
 
         {/* Conversion Type Selection */}
         <div className="mb-8 bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Select Conversion Type</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+            Select Conversion Type
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {conversionOptions.map((option) => (
               <button
                 key={option.value}
                 onClick={() => {
-                  setConversionType(option.value as ConversionType)
-                  setInputExpression(option.example)
-                  resetVisualization()
+                  setConversionType(option.value as ConversionType);
+                  setInputExpression(option.example);
+                  resetVisualization();
                 }}
-                className={`p-4 rounded-lg border-2 transition-all duration-200 text-left ${
-                  conversionType === option.value
-                    ? "border-blue-500 bg-blue-50 text-blue-700"
-                    : "border-gray-200 dark:border-slate-700 hover:border-gray-300 hover:bg-gray-50"
-                }`}
+                className={`p-4 rounded-lg border-2 transition-all duration-200 text-left
+          ${
+            conversionType === option.value
+              ? "border-blue-500 bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-300"
+              : "border-gray-200 dark:border-slate-700 hover:border-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700"
+          }`}
               >
                 <div className="font-semibold">{option.label}</div>
-                <div className="text-sm text-gray-600 dark:text-gray-300 mt-1">Example: {option.example}</div>
+                <div className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+                  Example: {option.example}
+                </div>
               </button>
             ))}
           </div>
@@ -732,10 +796,15 @@ postfix_result = infix_to_postfix(infix_result)`,
 
         {/* Input Section */}
         <div className="mb-8 bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Input Expression</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+            Input Expression
+          </h2>
           <div className="flex flex-col gap-4">
             <div>
-              <label htmlFor="expression-input" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="expression-input"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              >
                 Expression
               </label>
               <input
@@ -743,11 +812,12 @@ postfix_result = infix_to_postfix(infix_result)`,
                 type="text"
                 value={inputExpression}
                 onChange={(e) => setInputExpression(e.target.value)}
-                className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500"
+                className="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
                 placeholder="Enter expression (e.g., A + B * C)"
               />
-              <p className="text-sm text-gray-500 mt-1">
-                Use letters for operands and +, -, *, /, ^ for operators. Parentheses are supported.
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Use letters for operands and +, -, *, /, ^ for operators.
+                Parentheses are supported.
               </p>
             </div>
             <div className="flex gap-4">
@@ -759,9 +829,13 @@ postfix_result = infix_to_postfix(infix_result)`,
                 {isVisualizing ? "Converting..." : "Convert"}
               </button>
               {result && (
-                <div className="flex items-center space-x-2 px-4 py-3 bg-green-50 rounded-lg">
-                  <span className="text-green-800 font-semibold">Result:</span>
-                  <span className="text-green-700 font-mono">{result}</span>
+                <div className="flex items-center space-x-2 px-4 py-3 bg-green-50 dark:bg-green-900 rounded-lg">
+                  <span className="text-green-800 dark:text-green-300 font-semibold">
+                    Result:
+                  </span>
+                  <span className="text-green-700 dark:text-green-200 font-mono">
+                    {result}
+                  </span>
                 </div>
               )}
             </div>
@@ -773,22 +847,27 @@ postfix_result = infix_to_postfix(infix_result)`,
           <div className="space-y-8">
             {/* Expression Visualization */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Expression Processing</h2>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                Expression Processing
+              </h2>
               <div className="space-y-4">
                 {/* Input Expression */}
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-800 mb-2">Input Expression</h3>
+                  <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
+                    Input Expression
+                  </h3>
                   <div className="flex flex-wrap gap-2 justify-center">
                     {tokenize(steps[currentStep].input).map((token, index) => (
                       <div
                         key={index}
-                        className={`w-12 h-12 flex items-center justify-center rounded-lg text-lg font-semibold transition-all duration-200 ${
-                          index === steps[currentStep].tokenIndex
-                            ? "bg-blue-500 text-white shadow-lg"
-                            : isOperator(token)
-                              ? "bg-orange-100 text-orange-700"
-                              : "bg-gray-100 text-gray-700"
-                        }`}
+                        className={`w-12 h-12 flex items-center justify-center rounded-lg text-lg font-semibold transition-all duration-200
+                  ${
+                    index === steps[currentStep].tokenIndex
+                      ? "bg-blue-500 text-white shadow-lg"
+                      : isOperator(token)
+                      ? "bg-orange-100 dark:bg-orange-900 text-orange-700 dark:text-orange-300"
+                      : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+                  }`}
                       >
                         {token}
                       </div>
@@ -799,9 +878,13 @@ postfix_result = infix_to_postfix(infix_result)`,
                 {/* Current Token */}
                 {steps[currentStep].currentToken && (
                   <div className="text-center">
-                    <div className="inline-flex items-center space-x-2 px-4 py-2 bg-blue-100 rounded-lg">
-                      <span className="text-blue-800 font-semibold">Current Token:</span>
-                      <span className="text-blue-700 font-mono text-lg">{steps[currentStep].currentToken}</span>
+                    <div className="inline-flex items-center space-x-2 px-4 py-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
+                      <span className="text-blue-800 dark:text-blue-300 font-semibold">
+                        Current Token:
+                      </span>
+                      <span className="text-blue-700 dark:text-blue-200 font-mono text-lg">
+                        {steps[currentStep].currentToken}
+                      </span>
                     </div>
                   </div>
                 )}
@@ -810,24 +893,31 @@ postfix_result = infix_to_postfix(infix_result)`,
 
             {/* Stack Visualization */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Stack State</h2>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                Stack State
+              </h2>
               <div className="flex flex-col-reverse items-center gap-2 min-h-[100px]">
                 {steps[currentStep].stack.length === 0 ? (
-                  <div className="text-gray-500 italic">Stack is empty</div>
+                  <div className="text-gray-500 dark:text-gray-400 italic">
+                    Stack is empty
+                  </div>
                 ) : (
                   steps[currentStep].stack.map((element, index) => (
                     <div
                       key={index}
-                      className={`min-w-[80px] h-12 flex items-center justify-center rounded-lg border-2 transition-all duration-200 px-2 ${
-                        element.isActive
-                          ? "border-blue-500 bg-blue-50 text-blue-700"
-                          : element.isOperator
-                            ? "border-orange-300 bg-orange-50 text-orange-700"
-                            : "border-gray-300 bg-gray-50 text-gray-700"
-                      }`}
+                      className={`min-w-[80px] h-12 flex items-center justify-center rounded-lg border-2 transition-all duration-200 px-2
+                ${
+                  element.isActive
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-300"
+                    : element.isOperator
+                    ? "border-orange-300 bg-orange-50 dark:bg-orange-900 text-orange-700 dark:text-orange-300"
+                    : "border-gray-300 bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+                }`}
                     >
                       <div className="text-center">
-                        <div className="text-sm font-semibold truncate">{element.value}</div>
+                        <div className="text-sm font-semibold truncate">
+                          {element.value}
+                        </div>
                       </div>
                     </div>
                   ))
@@ -837,15 +927,19 @@ postfix_result = infix_to_postfix(infix_result)`,
 
             {/* Output Visualization */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Output</h2>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                Output
+              </h2>
               <div className="flex flex-wrap gap-2 justify-center min-h-[60px] items-center">
                 {steps[currentStep].output.length === 0 ? (
-                  <div className="text-gray-500 italic">Output is empty</div>
+                  <div className="text-gray-500 dark:text-gray-400 italic">
+                    Output is empty
+                  </div>
                 ) : (
                   steps[currentStep].output.map((token, index) => (
                     <div
                       key={index}
-                      className="min-w-[40px] h-12 flex items-center justify-center rounded-lg bg-green-100 text-green-700 border border-green-300 font-semibold px-2"
+                      className="min-w-[40px] h-12 flex items-center justify-center rounded-lg bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-200 border border-green-300 dark:border-green-700 font-semibold px-2"
                     >
                       {token}
                     </div>
@@ -856,17 +950,23 @@ postfix_result = infix_to_postfix(infix_result)`,
 
             {/* Step Information */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Step Information</h2>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                Step Information
+              </h2>
               <div className="space-y-4">
                 <div className="flex justify-between items-center">
                   <div>
-                    <p className="text-gray-700">{steps[currentStep].description}</p>
+                    <p className="text-gray-700 dark:text-gray-300">
+                      {steps[currentStep].description}
+                    </p>
                   </div>
                   <div className="flex items-center space-x-4">
                     <button
-                      onClick={() => setCurrentStep((prev) => Math.max(0, prev - 1))}
+                      onClick={() =>
+                        setCurrentStep((prev) => Math.max(0, prev - 1))
+                      }
                       disabled={currentStep === 0}
-                      className="p-2 hover:bg-gray-100 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <ChevronLeft className="w-6 h-6 text-gray-600 dark:text-gray-300" />
                     </button>
@@ -874,9 +974,13 @@ postfix_result = infix_to_postfix(infix_result)`,
                       Step {currentStep + 1} of {steps.length}
                     </span>
                     <button
-                      onClick={() => setCurrentStep((prev) => Math.min(steps.length - 1, prev + 1))}
+                      onClick={() =>
+                        setCurrentStep((prev) =>
+                          Math.min(steps.length - 1, prev + 1)
+                        )
+                      }
                       disabled={currentStep === steps.length - 1}
-                      className="p-2 hover:bg-gray-100 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <ChevronRight className="w-6 h-6 text-gray-600 dark:text-gray-300" />
                     </button>
@@ -888,40 +992,57 @@ postfix_result = infix_to_postfix(infix_result)`,
             {/* Code Section */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Code</h2>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+                  Code
+                </h2>
                 <button
                   onClick={() => setShowFullCode(!showFullCode)}
                   className="flex items-center space-x-2 text-blue-600 hover:text-blue-700"
                 >
                   <Code className="w-5 h-5" />
-                  <span>{showFullCode ? "Show Current Step" : "Show Full Code"}</span>
+                  <span>
+                    {showFullCode ? "Show Current Step" : "Show Full Code"}
+                  </span>
                 </button>
               </div>
-              <pre className="bg-gray-50 p-4 rounded-lg overflow-x-auto">
-                <code className="text-sm text-gray-800">{showFullCode ? getFullCode() : steps[currentStep]?.code}</code>
+              <pre className="bg-gray-50 dark:bg-slate-700 p-4 rounded-lg overflow-x-auto">
+                <code className="text-sm text-gray-800 dark:text-gray-200">
+                  {showFullCode ? getFullCode() : steps[currentStep]?.code}
+                </code>
               </pre>
             </div>
 
             {/* Algorithm Insights */}
             <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-gray-200 dark:border-slate-700 p-6">
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Algorithm Insights</h2>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                Algorithm Insights
+              </h2>
               <div className="space-y-3 text-sm">
-                <div className="p-3 bg-blue-50 rounded-lg">
-                  <div className="font-semibold text-blue-800">Stack Usage:</div>
-                  <div className="text-blue-700">
-                    Stack is used to temporarily store operators and manage precedence during conversion
+                <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900">
+                  <div className="font-semibold text-blue-800 dark:text-blue-300">
+                    Stack Usage:
+                  </div>
+                  <div className="text-blue-700 dark:text-blue-200">
+                    Stack is used to temporarily store operators and manage
+                    precedence during conversion
                   </div>
                 </div>
-                <div className="p-3 bg-purple-50 rounded-lg">
-                  <div className="font-semibold text-purple-800">Precedence Rules:</div>
-                  <div className="text-purple-700">
-                    ^ (highest) → *, / → +, - (lowest). Higher precedence operators are processed first
+                <div className="p-3 rounded-lg bg-purple-50 dark:bg-purple-900">
+                  <div className="font-semibold text-purple-800 dark:text-purple-300">
+                    Precedence Rules:
+                  </div>
+                  <div className="text-purple-700 dark:text-purple-200">
+                    ^ (highest) → *, / → +, - (lowest). Higher precedence
+                    operators are processed first
                   </div>
                 </div>
-                <div className="p-3 bg-green-50 rounded-lg">
-                  <div className="font-semibold text-green-800">Applications:</div>
-                  <div className="text-green-700">
-                    Compilers, calculators, and expression evaluators use these conversions for parsing
+                <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900">
+                  <div className="font-semibold text-green-800 dark:text-green-300">
+                    Applications:
+                  </div>
+                  <div className="text-green-700 dark:text-green-200">
+                    Compilers, calculators, and expression evaluators use these
+                    conversions for parsing
                   </div>
                 </div>
               </div>
@@ -930,9 +1051,7 @@ postfix_result = infix_to_postfix(infix_result)`,
         )}
       </main>
     </div>
-  )
+  );
 }
 
-export default ExpressionConverterPage
-
-
+export default ExpressionConverterPage;

--- a/src/pages/SortingAlgorithmsPage.tsx
+++ b/src/pages/SortingAlgorithmsPage.tsx
@@ -74,10 +74,12 @@ function SortingAlgorithmsPage() {
     }, 0);
   };
 
+  /* Commented out to fix Netlify build error (unused variable)
   const handleInputSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (inputArray.trim()) setShowVisualization(true);
   };
+  */
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-100 via-white to-gray-200 dark:from-slate-950 dark:via-slate-900 dark:to-gray-900 transition-colors duration-500">


### PR DESCRIPTION
### 🐞 Issue #173: Dark Mode Incompatibility on Expression Converter Page

The Expression Converter page and its related visualization sections are not fully compatible with dark mode. Certain elements such as input fields, result boxes, step visualizations, algorithm insight cards, and colored token/stack boxes remain in light colors, which reduces readability and affects user experience.

---

### 📸 Screenshot:
**Before**
<img width="1920" height="1020" alt="Screenshot 2025-10-25 173635" src="https://github.com/user-attachments/assets/960e5709-a717-4e8d-b564-2e1d20b47aec" />

**After**
<img width="1920" height="1020" alt="Screenshot 2025-10-25 180842" src="https://github.com/user-attachments/assets/2c27ed97-522c-4e98-8494-e2d68c8e5721" />
